### PR TITLE
Limited image storage to 300 images

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
   "devDependencies": {
     "del": "^1.2.0",
     "event-stream": "^3.1.0",
-    "gulp": "^3.9.0",
+    "gulp": "^3.9.1",
     "gulp-angular-templatecache": "^1.1.0",
     "gulp-concat": "^2.1.7",
     "gulp-gh-pages": "^0.5.4",


### PR DESCRIPTION
#### What's new
- Limited image storage to 300 images (~ 3MB of local storage)
- Works as a FIFO cache

We can increase the number if we need to in the future. 