### PR TITLE
Supergroup name filtering

### DIFF
--- a/app/js/immedia/immedia-directive.js
+++ b/app/js/immedia/immedia-directive.js
@@ -47,6 +47,10 @@ angular.module('immedia', ['immediaControllers','immediaServices'])
       var currentRoomId;
       $scope.$watchCollection('curDialog', function(dialog) {
         currentRoomId = dialog.peer;
+        // EKUCODE(german-e-mas): Filter the group ID of supergroups.
+        if (currentRoomId.startsWith('s')) {
+          currentRoomId = currentRoomId.substring(0, currentRoomId.indexOf('_'));
+        }
         // if (cfgSvc.isAwarenessEnabled(roomId)) {
         console.log('xxx current room:' + currentRoomId);
       });

--- a/app/js/immedia/immedia-room-controller.js
+++ b/app/js/immedia/immedia-room-controller.js
@@ -31,6 +31,10 @@
     //Checks for room selection change
     $scope.$watchCollection('curDialog', function(dialog) {
       var roomId = dialog.peer;
+      // EKUCODE(german-e-mas): Filter the group ID of supergroups.
+      if (roomId.startsWith('s')) {
+        roomId = roomId.substring(0, roomId.indexOf('_'));
+      }
 
       if ($scope.roomName === roomId) {
         return;


### PR DESCRIPTION
Allows Immedia to use super groups (that is, groups with admins).

Normal groups have a consistent naming structure. They start with `g` followed by an ID. Super groups names are different for each user. They start with `s`, followed by an ID and an underscore which is followed by another ID which is different for each user. I haven't found any docs on the Telegram API on what is the meaning of this dynamic ID.

Since the Immedia room name is equal to the group ID, we end up with one room per participant. This change makes the Immedia room name uniform for participants to be together in that room.